### PR TITLE
Disabling some not needed cache re-validation

### DIFF
--- a/premarum-web-client/utility/hooks/useCoursesTaken.ts
+++ b/premarum-web-client/utility/hooks/useCoursesTaken.ts
@@ -8,7 +8,7 @@ import removeCourseTaken from "../requests/removeCoursesTaken";
 export function useCoursesTaken() {
     const { data, error, mutate } = useSWR('CoursesTaken', async () => {
         return (await getCoursesTaken(pca)).data
-    })
+    }, {revalidateIfStale:false})
     
     async function addCoursesTakenToCache(courseIds: number[]) {
         await mutate(async (cachedData:any) => {

--- a/premarum-web-client/utility/hooks/usePreEnrollments.ts
+++ b/premarum-web-client/utility/hooks/usePreEnrollments.ts
@@ -31,7 +31,7 @@ export function usePreEnrollment(preEnrollmentId: number | null) {
         if (preEnrollmentId != null) {
             return await getStudentPreEnrollmentById(preEnrollmentId, pca)
         }
-    })
+    }, {revalidateIfStale:false})
     
     async function updateCache(selections: number[]) {
         await mutate(async cachedData => {

--- a/premarum-web-client/utility/hooks/useSemesterOfferings.ts
+++ b/premarum-web-client/utility/hooks/useSemesterOfferings.ts
@@ -5,7 +5,7 @@ import {IPreEnrollmentSelectionResponse} from "../requests/responseTypes";
 export function useSemesterOfferings(semesterId: number) {
     const {data, error} = useSWR(`semesterOfferingsFetch-${semesterId}`, async () => {
         return await getSemesterCourseOfferings(semesterId);  
-    })
+    }, {revalidateIfStale:false})
 
     return {
         courseOfferings: data as IPreEnrollmentSelectionResponse[],

--- a/premarum-web-client/utility/hooks/useStudent.ts
+++ b/premarum-web-client/utility/hooks/useStudent.ts
@@ -8,7 +8,7 @@ import addStudentDepartment from "../requests/addStudentDepartment";
 export function useStudent() {
     const { data, error, mutate } = useSWR('useStudent', async () => {
         return await getOrCreateUser(pca)
-    })
+    }, {revalidateIfStale: false})
 
     async function updateStudentDepartment(departmentId: number) {
         await mutate(async cachedData => {


### PR DESCRIPTION
* Student does not change from outside sources often
* CoursesTaken get updated each time you add or remove
* PreEnrollment Gets edit in client every time you add or remove selection
* Course offerings do not change often by external


Home needs revalidation to refetch after changes in to a specific preenrollment



