### PR TITLE
Fix filtering in data grids

### DIFF
--- a/premarum-web-client/utility/helpers/ColumnFormat.tsx
+++ b/premarum-web-client/utility/helpers/ColumnFormat.tsx
@@ -1,5 +1,6 @@
 import { Box, styled, Tooltip, tooltipClasses, TooltipProps, Typography } from "@mui/material"
-import { ITimeSlotResponse } from "../requests/responseTypes";
+import {ICourseResponse, ITimeSlotResponse} from "../requests/responseTypes";
+import {GridCellValue, GridColDef} from "@mui/x-data-grid";
 
 const CustomTooltip = styled(({ className, ...props }: TooltipProps) => (
     <Tooltip {...props} classes={{ popper: className }} />
@@ -10,27 +11,31 @@ const CustomTooltip = styled(({ className, ...props }: TooltipProps) => (
 });
 
 export function GetColumnFormat(props: {creditSum: number | null}) {
-    const columns = [
+    const columns:GridColDef[] = [
         {field: 'course', headerName: 'Course', minWidth: 100, description: '',
-            renderCell: (params: any) => (
-                <CustomTooltip title={`${params.value.courseCode} - ${params.value.courseName}`} placement="right" arrow>
-                    <Box>{params.value.courseCode}</Box>
+            renderCell: (params: any) => {
+                const val: ICourseResponse = JSON.parse(params.value)
+                return <CustomTooltip title={`${val.courseCode} - ${val.courseName}`} placement="right"
+                               arrow>
+                    <Box>{val.courseCode}</Box>
                 </CustomTooltip>
-            )
+            }
         },
         {field: 'section', headerName: 'Section', minWidth: 100, description: ''},
         {field: 'credits', headerName: props.creditSum? `Credits [${props.creditSum}]`:"Credits", minWidth: 100, description: ''},
         {field: 'classroom', headerName: 'Classroom', minWidth: 100, description: ''},
         {field: 'timeslot', headerName: 'Timeslot', minWidth: 150, flex: 1, description: '',
-            renderCell: (params: any) => (
-                <Box sx={{ whiteSpace: 'normal', overflowY: 'auto', maxHeight: 75, width: '100%'}}>
-                    {((params.value) as ITimeSlotResponse[]).map((val, index) => {
-                        return(
-                            <Typography sx={{fontSize: '0.875rem'}}>{`${val.day.substring(0, 3)} | ${val.startTime} - ${val.endTime}`}</Typography>
+            renderCell: (params: any) => {
+                const tsArray: ITimeSlotResponse[] = JSON.parse(params.value)
+                return <Box sx={{whiteSpace: 'normal', overflowY: 'auto', maxHeight: 75, width: '100%'}}>
+                    {tsArray.map((val, index) => {
+                        return (
+                            <Typography
+                                sx={{fontSize: '0.875rem'}}>{`${val.day.substring(0, 3)} | ${val.startTime} - ${val.endTime}`}</Typography>
                         )
                     })}
                 </Box>
-            )
+            }
         },
         {field: 'professor', headerName: 'Professor', minWidth: 150, flex: 1, description: '',
             renderCell: (params: any) => (

--- a/premarum-web-client/utility/helpers/selectionToRow.ts
+++ b/premarum-web-client/utility/helpers/selectionToRow.ts
@@ -13,11 +13,11 @@ export async function GetRows(selections: IPreEnrollmentSelectionResponse[]) {
         result.push({
             id: parseInt(i), 
             entryId: selections[i].id, 
-            course: selections[i].course, 
+            course: JSON.stringify(selections[i].course), 
             section: selections[i].sectionName,
             credits: selections[i].course.courseCredit, 
             classroom: selections[i].classRoom,
-            timeslot: selections[i].timeSlots,
+            timeslot: JSON.stringify(selections[i].timeSlots),
             professor: professors.join(", "), 
             prerequisites: selections[i].course.coursePrerequisites,
             corequisites: selections[i].course.courseCorequisites,

--- a/premarum-web-client/utility/helpers/selectionToRow.ts
+++ b/premarum-web-client/utility/helpers/selectionToRow.ts
@@ -13,7 +13,10 @@ export async function GetRows(selections: IPreEnrollmentSelectionResponse[]) {
         result.push({
             id: parseInt(i), 
             entryId: selections[i].id, 
-            course: JSON.stringify(selections[i].course), 
+            course: JSON.stringify({
+                courseCode:selections[i].course.courseCode, 
+                courseName: selections[i].course.courseName
+            }), 
             section: selections[i].sectionName,
             credits: selections[i].course.courseCredit, 
             classroom: selections[i].classRoom,


### PR DESCRIPTION
Simple temp fix by converting value into a json string and then parsing it when its time to render.

Cons of approach:
* if somebody searches for courseCode, courseName, ... all will appear 
* If somebody searches for a json symbol all will appear

The preview page is included in azure so testing can be done in the preview deployment